### PR TITLE
cmake: add /usr/lib64/ to search list of cairommconfig.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ visualiser_dependency(GLEW_FOUND "GLEW library")
 #visualiser_dependency(GLX_FOUND "GLX library")
 
 find_path(CAIROMM_INCLUDE_PATH "cairomm.h" PATH_SUFFIXES "cairomm" "cairomm-1.0/cairomm")
-find_path(CAIROMM_CONFIG_PATH "cairommconfig.h" PATHS "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}" PATH_SUFFIXES "cairomm" "cairomm-1.0/cairomm" "cairomm-1.0/include" "lib/cairomm-1.0/include")
+find_path(CAIROMM_CONFIG_PATH "cairommconfig.h" PATHS "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}" "/usr/lib64/${CMAKE_LIBRARY_ARCHITECTURE}" PATH_SUFFIXES "cairomm" "cairomm-1.0/cairomm" "cairomm-1.0/include" "lib/cairomm-1.0/include")
 
 if(${CAIROMM_INCLUDE_PATH} STREQUAL "CAIROMM_INCLUDE_PATH-NOTFOUND" OR ${CAIROMM_CONFIG_PATH} STREQUAL "CAIROMM_CONFIG_PATH-NOTFOUND")
    message("-- Cairomm headers not found - visualiser will not be built")


### PR DESCRIPTION
I've tried to build DynamO for Fedora 27 x86_64, then I noticed cairomm cannot be detected correctly.
Fedora 27 x86_64 installs cairommconfig.h to /usr/lib64/cairomm-1.0/include/cairommconfig.h.
This makes CMake also search cairommconfig.h under /usr/lib64.

I do not have enough knowledge about CMake, so this may be not a good way to fix the issue. But at least, with this patch dynamo visualizer can be built.